### PR TITLE
Make jamenkaye codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for
 # review when someone opens a pull request.
-* @patrick-5546
+* @patrick-5546 @jamenkaye


### PR DESCRIPTION
@jamenkaye adding you as codeowner so that you get notified when PRs are made. My thinking is that my reviews will more focus more on code quality and architecture, whereas yours can focus more on functionality and implementation