### PR TITLE
Fix gitignore directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-*.pyc
+# python
+__pycache__/
+.mypy_cache/
+.pytest_cache/


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->
To grey out a directory in the vs code explorer, need to remove `*` at the end of directories. This is only required if you want to exclude files in that directory from being ignored.