### PR TITLE
Use HelperLatLon instead of LatLon

### DIFF
--- a/local_pathfinding/coord_systems.py
+++ b/local_pathfinding/coord_systems.py
@@ -3,21 +3,10 @@
 import math
 from typing import NamedTuple
 
+from custom_interfaces.msg import HelperLatLon
 from pyproj import Geod
 
 GEODESIC = Geod(ellps="WGS84")
-
-
-class LatLon(NamedTuple):
-    """Geographical coordinate representation.
-
-    Attributes:
-        latitude (float): Latitude in degrees.
-        longitude (float): Longitude in degrees.
-    """
-
-    latitude: float
-    longitude: float
 
 
 class XY(NamedTuple):
@@ -52,12 +41,12 @@ def km_to_meters(km: float) -> float:
     return km * 1000
 
 
-def latlon_to_xy(reference: LatLon, latlon: LatLon) -> XY:
+def latlon_to_xy(reference: HelperLatLon, latlon: HelperLatLon) -> XY:
     """Convert a geographical coordinate to a 2D Cartesian coordinate given a reference point.
 
     Args:
-        reference (LatLon): Coordinate that will be the origin of the Cartesian coordinate system.
-        latlon (LatLon): Coordinate to be converted to the Cartesian coordinate system.
+        reference (HelperLatLon): Origin of the Cartesian coordinate system.
+        latlon (HelperLatLon): Coordinate to be converted to the Cartesian coordinate system.
 
     Returns:
         XY: The x and y components in km.
@@ -74,15 +63,15 @@ def latlon_to_xy(reference: LatLon, latlon: LatLon) -> XY:
     )
 
 
-def xy_to_latlon(reference: LatLon, xy: XY) -> LatLon:
+def xy_to_latlon(reference: HelperLatLon, xy: XY) -> HelperLatLon:
     """Convert a 2D Cartesian coordinate to a geographical coordinate given a reference point.
 
     Args:
-        reference (LatLon): Coordinate that is the origin of the Cartesian coordinate system.
+        reference (HelperLatLon): Coordinate that is the origin of the Cartesian coordinate system.
         xy (XY): Coordinate to be converted to the geographical coordinate system.
 
     Returns:
-        LatLon: The latitude and longitude in degrees.
+        HelperLatLon: The latitude and longitude in degrees.
     """
     true_bearing = math.degrees(math.atan2(xy.x, xy.y))
     distance = km_to_meters(math.hypot(*xy))
@@ -90,4 +79,4 @@ def xy_to_latlon(reference: LatLon, xy: XY) -> LatLon:
         reference.longitude, reference.latitude, true_bearing, distance
     )
 
-    return LatLon(latitude=dest_lat, longitude=dest_lon)
+    return HelperLatLon(latitude=dest_lat, longitude=dest_lon)

--- a/local_pathfinding/objectives.py
+++ b/local_pathfinding/objectives.py
@@ -3,6 +3,7 @@
 import math
 from enum import Enum, auto
 
+from custom_interfaces.msg import HelperLatLon
 from ompl import base as ob
 
 import local_pathfinding.coord_systems as cs
@@ -60,11 +61,16 @@ class DistanceObjective(Objective):
         method (DistanceMethod): The method of the distance objective function
         ompl_path_objective (ob.PathLengthOptimizationObjective): The OMPL path length objective.
             Only defined if the method is OMPL path length.
-        reference (cs.LatLon): The XY origin when converting from latlon to XY.
+        reference (HelperLatLon): The XY origin when converting from latlon to XY.
             Only defined if the method is latlon.
     """
 
-    def __init__(self, space_information, method: DistanceMethod, reference=cs.LatLon(0, 0)):
+    def __init__(
+        self,
+        space_information,
+        method: DistanceMethod,
+        reference=HelperLatLon(latitude=0.0, longitude=0.0),
+    ):
         super().__init__(space_information)
         self.method = method
         if self.method == DistanceMethod.OMPL_PATH_LENGTH:
@@ -115,7 +121,7 @@ class DistanceObjective(Objective):
         return math.hypot(s2.y - s1.y, s2.x - s1.x)
 
     @staticmethod
-    def get_latlon_path_length_objective(s1: cs.XY, s2: cs.XY, reference: cs.LatLon) -> float:
+    def get_latlon_path_length_objective(s1: cs.XY, s2: cs.XY, reference: HelperLatLon) -> float:
         """Generates the "great circle" distance between two points
 
         I am assuming that we are using the lat and long coordinates in determining the distance

--- a/test/test_coord_systems.py
+++ b/test/test_coord_systems.py
@@ -1,9 +1,9 @@
 import math
 
 import pytest
+from custom_interfaces.msg import HelperLatLon
 
 import local_pathfinding.coord_systems as coord_systems
-from local_pathfinding.coord_systems import XY, LatLon
 
 
 @pytest.mark.parametrize(
@@ -50,15 +50,15 @@ def test_km_to_meters(km: float, meters: float):
 )
 def test_latlon_to_xy(ref_lat: float, ref_lon: float, true_bearing_deg: float, dist_km: float):
     # create inputs
-    reference = LatLon(latitude=ref_lat, longitude=ref_lon)
+    reference = HelperLatLon(latitude=ref_lat, longitude=ref_lon)
     lon, lat, _ = coord_systems.GEODESIC.fwd(
         lons=ref_lon, lats=ref_lat, az=true_bearing_deg, dist=dist_km * 1000
     )
-    latlon = LatLon(latitude=lat, longitude=lon)
+    latlon = HelperLatLon(latitude=lat, longitude=lon)
 
     # create expected output
     true_bearing = math.radians(true_bearing_deg)
-    xy = XY(
+    xy = coord_systems.XY(
         x=dist_km * math.sin(true_bearing),
         y=dist_km * math.cos(true_bearing),
     )
@@ -83,18 +83,22 @@ def test_latlon_to_xy(ref_lat: float, ref_lon: float, true_bearing_deg: float, d
 def test_xy_to_latlon(ref_lat: float, ref_lon: float, true_bearing_deg: float, dist_km: float):
     # create inputs
     true_bearing = math.radians(true_bearing_deg)
-    xy = XY(
+    xy = coord_systems.XY(
         x=dist_km * math.sin(true_bearing),
         y=dist_km * math.cos(true_bearing),
     )
 
     # create expected output
-    reference = LatLon(latitude=ref_lat, longitude=ref_lon)
+    reference = HelperLatLon(latitude=ref_lat, longitude=ref_lon)
     lon, lat, _ = coord_systems.GEODESIC.fwd(
         lons=ref_lon, lats=ref_lat, az=true_bearing_deg, dist=dist_km * 1000
     )
-    latlon = LatLon(latitude=lat, longitude=lon)
+    latlon = HelperLatLon(latitude=lat, longitude=lon)
 
-    assert coord_systems.xy_to_latlon(reference, xy) == pytest.approx(
-        latlon
-    ), "incorrect coordinate conversion"
+    converted_latlon = coord_systems.xy_to_latlon(reference, xy)
+    assert converted_latlon.latitude == pytest.approx(
+        latlon.latitude
+    ), "incorrect latitude conversion"
+    assert converted_latlon.longitude == pytest.approx(
+        latlon.longitude
+    ), "incorrect longitude conversion"

--- a/test/test_coord_systems.py
+++ b/test/test_coord_systems.py
@@ -95,4 +95,7 @@ def test_xy_to_latlon(ref_lat: float, ref_lon: float, true_bearing_deg: float, d
     )
     latlon = HelperLatLon(latitude=lat, longitude=lon)
 
-    assert coord_systems.xy_to_latlon(reference, xy) == latlon, "incorrect coordinate conversion"
+    converted_latlon = coord_systems.xy_to_latlon(reference, xy)
+    assert (converted_latlon.latitude, converted_latlon.longitude) == pytest.approx(
+        (latlon.latitude, latlon.longitude)
+    ), "incorrect coordinate conversion"

--- a/test/test_coord_systems.py
+++ b/test/test_coord_systems.py
@@ -95,10 +95,4 @@ def test_xy_to_latlon(ref_lat: float, ref_lon: float, true_bearing_deg: float, d
     )
     latlon = HelperLatLon(latitude=lat, longitude=lon)
 
-    converted_latlon = coord_systems.xy_to_latlon(reference, xy)
-    assert converted_latlon.latitude == pytest.approx(
-        latlon.latitude
-    ), "incorrect latitude conversion"
-    assert converted_latlon.longitude == pytest.approx(
-        latlon.longitude
-    ), "incorrect longitude conversion"
+    assert coord_systems.xy_to_latlon(reference, xy) == latlon, "incorrect coordinate conversion"

--- a/test/test_objectives.py
+++ b/test/test_objectives.py
@@ -1,6 +1,7 @@
 import math
 
 import pytest
+from custom_interfaces.msg import HelperLatLon
 from rclpy.impl.rcutils_logger import RcutilsLogger
 
 import local_pathfinding.coord_systems as coord_systems
@@ -51,17 +52,17 @@ def test_get_euclidean_path_length_objective(cs1: tuple, cs2: tuple, expected: f
 @pytest.mark.parametrize(
     "rf, cs1,cs2",
     [
-        ((10, 10), (0, 0), (0, 0)),
+        ((10.0, 10.0), (0.0, 0.0), (0.0, 0.0)),
         ((13.206724, 29.829011), (13.208724, 29.827011), (13.216724, 29.839011)),
-        ((0, 0), (0, 0.1), (0, -0.1)),
-        ((0, 0), (0.1, 0), (-0.1, 0)),
-        ((0, 0), (0.1, 0.1), (-0.1, -0.1)),
+        ((0.0, 0.0), (0.0, 0.1), (0.0, -0.1)),
+        ((0.0, 0.0), (0.1, 0.0), (-0.1, 0.0)),
+        ((0.0, 0.0), (0.1, 0.1), (-0.1, -0.1)),
     ],
 )
 def test_get_latlon_path_length_objective(rf: tuple, cs1: tuple, cs2: tuple):
-    reference = coord_systems.LatLon(*rf)
-    s1 = coord_systems.LatLon(*cs1)
-    s2 = coord_systems.LatLon(*cs2)
+    reference = HelperLatLon(latitude=rf[0], longitude=rf[1])
+    s1 = HelperLatLon(latitude=cs1[0], longitude=cs1[1])
+    s2 = HelperLatLon(latitude=cs2[0], longitude=cs2[1])
     ls1 = coord_systems.latlon_to_xy(reference, s1)
     ls2 = coord_systems.latlon_to_xy(reference, s2)
     _, _, distance_m = coord_systems.GEODESIC.inv(

--- a/test/test_obstacles.py
+++ b/test/test_obstacles.py
@@ -10,7 +10,7 @@ from custom_interfaces.msg import (
 )
 from shapely.geometry import Point, Polygon
 
-from local_pathfinding.coord_systems import XY, LatLon, latlon_to_xy, meters_to_km
+from local_pathfinding.coord_systems import XY, latlon_to_xy, meters_to_km
 from local_pathfinding.obstacles import COLLISION_ZONE_SAFETY_BUFFER, Boat, Obstacle
 
 
@@ -20,8 +20,8 @@ from local_pathfinding.obstacles import COLLISION_ZONE_SAFETY_BUFFER, Boat, Obst
     "reference_point,sailbot_position,ais_ship,sailbot_speed",
     [
         (
-            LatLon(52.268119490007756, -136.9133983613776),
-            LatLon(51.957, -136.262),
+            HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+            HelperLatLon(latitude=51.957, longitude=-136.262),
             HelperAISShip(
                 id=1,
                 lat_lon=HelperLatLon(latitude=51.957, longitude=-136.262),
@@ -36,8 +36,8 @@ from local_pathfinding.obstacles import COLLISION_ZONE_SAFETY_BUFFER, Boat, Obst
     ],
 )
 def test_calculate_projected_distance(
-    reference_point: LatLon,
-    sailbot_position: LatLon,
+    reference_point: HelperLatLon,
+    sailbot_position: HelperLatLon,
     ais_ship: HelperAISShip,
     sailbot_speed: float,
 ):
@@ -53,8 +53,8 @@ def test_calculate_projected_distance(
     "reference_point,sailbot_position,ais_ship,sailbot_speed",
     [
         (
-            LatLon(52.268119490007756, -136.9133983613776),
-            LatLon(51.95785651405779, -136.26282894969611),
+            HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+            HelperLatLon(latitude=51.95785651405779, longitude=-136.26282894969611),
             HelperAISShip(
                 id=1,
                 lat_lon=HelperLatLon(latitude=51.97917631092298, longitude=-137.1106454702385),
@@ -69,8 +69,8 @@ def test_calculate_projected_distance(
     ],
 )
 def test_create_collision_zone(
-    reference_point: LatLon,
-    sailbot_position: LatLon,
+    reference_point: HelperLatLon,
+    sailbot_position: HelperLatLon,
     ais_ship: HelperAISShip,
     sailbot_speed: float,
 ):
@@ -88,8 +88,8 @@ def test_create_collision_zone(
     "reference_point,sailbot_position,ais_ship,sailbot_speed",
     [
         (
-            LatLon(52.0, -136.0),
-            LatLon(51.95785651405779, -136.26282894969611),
+            HelperLatLon(latitude=52.0, longitude=-136.0),
+            HelperLatLon(latitude=51.95785651405779, longitude=-136.26282894969611),
             HelperAISShip(
                 id=1,
                 lat_lon=HelperLatLon(latitude=52.0, longitude=-136.0),
@@ -104,8 +104,8 @@ def test_create_collision_zone(
     ],
 )
 def test_position_collision_zone(
-    reference_point: LatLon,
-    sailbot_position: LatLon,
+    reference_point: HelperLatLon,
+    sailbot_position: HelperLatLon,
     ais_ship: HelperAISShip,
     sailbot_speed: float,
 ):
@@ -125,8 +125,8 @@ def test_position_collision_zone(
     "reference_point,sailbot_position,ais_ship_1,ais_ship_2,sailbot_speed",
     [
         (
-            LatLon(52.268119490007756, -136.9133983613776),
-            LatLon(51.95785651405779, -136.26282894969611),
+            HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+            HelperLatLon(latitude=51.95785651405779, longitude=-136.26282894969611),
             HelperAISShip(
                 id=1,
                 lat_lon=HelperLatLon(latitude=51.97917631092298, longitude=-137.1106454702385),
@@ -150,8 +150,8 @@ def test_position_collision_zone(
     ],
 )
 def test_create_collision_zone_id_mismatch(
-    reference_point: LatLon,
-    sailbot_position: LatLon,
+    reference_point: HelperLatLon,
+    sailbot_position: HelperLatLon,
     ais_ship_1: HelperAISShip,
     ais_ship_2: HelperAISShip,
     sailbot_speed: float,
@@ -167,8 +167,8 @@ def test_create_collision_zone_id_mismatch(
     "reference_point,sailbot_position,ais_ship,sailbot_speed,invalid_point,valid_point",
     [
         (
-            LatLon(52.268119490007756, -136.9133983613776),
-            LatLon(51.95785651405779, -136.26282894969611),
+            HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+            HelperLatLon(latitude=51.95785651405779, longitude=-136.26282894969611),
             HelperAISShip(
                 lat_lon=HelperLatLon(latitude=51.97917631092298, longitude=-137.1106454702385),
                 cog=HelperHeading(heading=0.0),
@@ -179,19 +179,19 @@ def test_create_collision_zone_id_mismatch(
             ),
             15.0,
             latlon_to_xy(
-                LatLon(52.268119490007756, -136.9133983613776),
-                LatLon(52.174842845359755, -137.10372451905042),
+                HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+                HelperLatLon(latitude=52.174842845359755, longitude=-137.10372451905042),
             ),
             latlon_to_xy(
-                LatLon(52.268119490007756, -136.9133983613776),
-                LatLon(49.30499213908291, -123.31330140816111),
+                HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+                HelperLatLon(latitude=49.30499213908291, longitude=-123.31330140816111),
             ),
         )
     ],
 )
 def test_is_valid(
-    reference_point: LatLon,
-    sailbot_position: LatLon,
+    reference_point: HelperLatLon,
+    sailbot_position: HelperLatLon,
     ais_ship: HelperAISShip,
     sailbot_speed: float,
     invalid_point: XY,
@@ -207,23 +207,23 @@ def test_is_valid(
     "reference_point,sailbot_position,sailbot_speed,invalid_point,valid_point",
     [
         (
-            LatLon(52.268119490007756, -136.9133983613776),
-            LatLon(51.95785651405779, -136.26282894969611),
+            HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+            HelperLatLon(latitude=51.95785651405779, longitude=-136.26282894969611),
             15.0,
             latlon_to_xy(
-                LatLon(52.268119490007756, -136.9133983613776),
-                LatLon(52.174842845359755, -137.10372451905042),
+                HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+                HelperLatLon(latitude=52.174842845359755, longitude=-137.10372451905042),
             ),
             latlon_to_xy(
-                LatLon(52.268119490007756, -136.9133983613776),
-                LatLon(49.30499213908291, -123.31330140816111),
+                HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+                HelperLatLon(latitude=49.30499213908291, longitude=-123.31330140816111),
             ),
         )
     ],
 )
 def test_is_valid_no_collision_zone(
-    reference_point: LatLon,
-    sailbot_position: LatLon,
+    reference_point: HelperLatLon,
+    sailbot_position: HelperLatLon,
     sailbot_speed: float,
     invalid_point: XY,
     valid_point: XY,
@@ -240,10 +240,10 @@ def test_is_valid_no_collision_zone(
     "ref_point,sailbot_position_1,sailbot_speed_1,sailbot_position_2,sailbot_speed_2,ais_ship",
     [
         (
-            LatLon(52.268119490007756, -136.9133983613776),
-            LatLon(51.9, -136.2),
+            HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+            HelperLatLon(latitude=51.9, longitude=-136.2),
             15.0,
-            LatLon(52.9, -137.2),
+            HelperLatLon(latitude=52.9, longitude=-137.2),
             20.0,
             HelperAISShip(
                 id=1,
@@ -258,10 +258,10 @@ def test_is_valid_no_collision_zone(
     ],
 )
 def test_update_sailbot_data(
-    ref_point: LatLon,
-    sailbot_position_1: LatLon,
+    ref_point: HelperLatLon,
+    sailbot_position_1: HelperLatLon,
     sailbot_speed_1: float,
-    sailbot_position_2: LatLon,
+    sailbot_position_2: HelperLatLon,
     sailbot_speed_2: float,
     ais_ship: HelperAISShip,
 ):
@@ -277,9 +277,9 @@ def test_update_sailbot_data(
     "reference_point_1,reference_point_2,sailbot_position,ais_ship,sailbot_speed",
     [
         (
-            LatLon(52.2, -136.9),
-            LatLon(51, -136),
-            LatLon(51.95785651405779, -136.26282894969611),
+            HelperLatLon(latitude=52.2, longitude=-136.9),
+            HelperLatLon(latitude=51.0, longitude=-136.0),
+            HelperLatLon(latitude=51.95785651405779, longitude=-136.26282894969611),
             HelperAISShip(
                 id=1,
                 lat_lon=HelperLatLon(latitude=51.97917631092298, longitude=-137.1106454702385),
@@ -292,9 +292,9 @@ def test_update_sailbot_data(
             15.0,
         ),
         (
-            LatLon(50.06442134644842, -130.7725487868677),
-            LatLon(49.88670956993386, -130.37061359404225),
-            LatLon(51.95785651405779, -136.26282894969611),
+            HelperLatLon(latitude=50.06442134644842, longitude=-130.7725487868677),
+            HelperLatLon(latitude=49.88670956993386, longitude=-130.37061359404225),
+            HelperLatLon(latitude=51.95785651405779, longitude=-136.26282894969611),
             HelperAISShip(
                 id=1,
                 lat_lon=HelperLatLon(latitude=51.97917631092298, longitude=-137.1106454702385),
@@ -309,9 +309,9 @@ def test_update_sailbot_data(
     ],
 )
 def test_update_reference_point(
-    reference_point_1: LatLon,
-    reference_point_2: LatLon,
-    sailbot_position: LatLon,
+    reference_point_1: HelperLatLon,
+    reference_point_2: HelperLatLon,
+    sailbot_position: HelperLatLon,
     ais_ship: HelperAISShip,
     sailbot_speed: float,
 ):
@@ -384,15 +384,15 @@ if __name__ == "__main__":
 
     # Create a boat object
     boat1 = Boat(
-        LatLon(52.268119490007756, -136.9133983613776),
-        LatLon(51.95785651405779, -136.26282894969611),
+        HelperLatLon(latitude=52.268119490007756, longitude=-136.9133983613776),
+        HelperLatLon(latitude=51.95785651405779, longitude=-136.26282894969611),
         30.0,
         ais_ship,
     )
 
     # Choose some states for visual inspection
-    valid_state = LatLon(50.42973337261916, -134.12018940923838)
-    invalid_state = LatLon(52.174842845359755, -137.10372451905042)
+    valid_state = HelperLatLon(latitude=50.42973337261916, longitude=-134.12018940923838)
+    invalid_state = HelperLatLon(latitude=52.174842845359755, longitude=-137.10372451905042)
 
     # Extract coordinates for sailbot
     sailbot_x, sailbot_y = boat1.sailbot_position


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Removed `coord_systems.LatLon` as it is redundant with `custom_interfaces.msg.HelperLatLon`
- This is a **breaking change**, may have to resolve merge conflicts with open PR's after merging (so may want to get your PR's in first)
    - However I want to merge this into #74 before continuing
- One difference is that you can't instantiate with `HelperLatLon(*latlon)`
    - Must explicitly name arguments: `HelperLatLon(latitude=latlon[0], longitude=latlon[1])`
    - This is a good practice anyways, just more verbose

@UBCSailbot/pathfinding FYI

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Tests task passes
