### PR TITLE
Migrate Local Pathfinding Python Dependencies to package.xml

### DIFF
--- a/global_paths/path_builder/requirements.txt
+++ b/global_paths/path_builder/requirements.txt
@@ -1,2 +1,0 @@
-Flask 3.0.0
-Werkzeug 3.0.1

--- a/package.xml
+++ b/package.xml
@@ -21,11 +21,6 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
-  <test_depend>python3-pytest</test_depend>
-
 
   <export>
     <build_type>ament_python</build_type>

--- a/package.xml
+++ b/package.xml
@@ -8,15 +8,18 @@
   <license>MIT</license>
 
   <!--ROS Dependencies-->
-  <exec_depend>rclpy</exec_depend>
   <exec_depend>custom_interfaces</exec_depend>
+  <exec_depend>rclpy</exec_depend>
 
   <!--Python Dependencies-->
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-pyproj</exec_depend>
   <exec_depend>python3-shapely</exec_depend>
-  <exec_depend>python3-numpy</exec_depend>
 
   <!--Test Dependencies-->
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -7,9 +7,16 @@
   <maintainer email="software@ubcsailbot.org">Patrick Creighton</maintainer>
   <license>MIT</license>
 
+  <!--ROS Dependencies-->
   <exec_depend>rclpy</exec_depend>
   <exec_depend>custom_interfaces</exec_depend>
 
+  <!--Python Dependencies-->
+  <exec_depend>python3-pyproj</exec_depend>
+  <exec_depend>python3-shapely</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+
+  <!--Test Dependencies-->
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,11 @@
 
   <!--Test Dependencies-->
   <test_depend>python3-pytest</test_depend>
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
 
   <export>
     <build_type>ament_python</build_type>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# packages that aren't required on the main computer in production
+# install them with pip3 install -r requirements.txt
+
+# global_paths/path_builder/path_builder.py
+flask
+
+# test/test_obstacles.py
+plotly


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- Resolves to #89 
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->

Added local_pathfinding Python dependencies to the package.xml file
I also removed these dependencies from the base-dev.Dockerfile in a separate SailbotWorkspace branch.

I did not remove NumPy from the Dockerfile, but I still added it to package.xml, which might be redundant but it does make it clear that this package specifically depends on NumPy.

The OMPL dependency is still defined in the base-dev.Dockerfile.

### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->

1. I removed the Python dependencies from `base-dev.Dockerfile`, then built a new image based off of the new Dockerfile.
2. I modified the Dev Container Dockerfile to use this new image and rebuilt the container.
3. I ran the `setup` task and then the command `pip3 list`
4. The Python dependencies specifed both in `base-dev.Dockerfile`and in `local_pathfinding/package.xml` were all installed successfully

